### PR TITLE
add: validator rules and mSUD to SUD conversion grs

### DIFF
--- a/converter/grs/zh_mSUD_to_SUD.grs
+++ b/converter/grs/zh_mSUD_to_SUD.grs
@@ -1,7 +1,5 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-include "SUD_to_UD.grs"
-
-strat zh_main { 
+strat zh_mSUD_to_SUD_main { 
   Seq (
     Onf (fusion)
   )

--- a/converter/grs/zh_mSUD_to_SUD.grs
+++ b/converter/grs/zh_mSUD_to_SUD.grs
@@ -1,0 +1,74 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+include "SUD_to_UD.grs"
+
+strat zh_main { 
+  Seq (
+    Onf (fusion)
+  )
+}
+
+
+package fusion {
+  rule suff_fusion_extpos {
+    pattern {
+      N [ExtPos];
+      N -[deep=m]-> M;  % M is attached with the :m extension
+      N < M             % M is a suffix
+    }  
+    without { M -> X}         % M is a leaf (force application order)
+    commands { 
+      N.form = N.form + M.form;             % concatenate the surface form
+      N.wordform = N.wordform + M.wordform; % concatenate the surface form
+      N.lemma = N.lemma + M.lemma;          % concatenate the surface lemma
+      del_node M;
+      N.upos = N.ExtPos; del_feat N.ExtPos;
+    }
+  }
+
+  rule suff_fusion {
+    pattern {
+      N[!ExtPos];
+      N -[deep=m]-> M;  % M is attached with the :m extension
+      N < M          % M is a suffix
+    }  
+    without { M -> X}         % M is a leaf (force application order)
+    commands { 
+      N.form = N.form + M.form;              % concatenate the surface form
+      N.wordform = N.wordform + M.wordform;  % concatenate the surface form
+      N.lemma = N.lemma + M.lemma;           % concatenate the surface lemma
+      del_node M;                % concatenate the surface form
+    }
+  }
+  
+  rule pref_fusion_extpos {
+    pattern {
+      N [ExtPos];
+      N -[deep=m]-> M;  % M is attached with the :m extension
+      M < N          % M is a prefix
+    }  
+    without { M -> X}         % M is a leaf (force application order)
+    commands { 
+      N.form = M.form + N.form;              % concatenate the surface form
+      N.wordform = M.wordform + N.wordform;  % concatenate the surface form
+      N.lemma = M.lemma + N.lemma;           % concatenate the surface lemma
+      del_node M;
+      N.upos = N.ExtPos; del_feat N.ExtPos;
+    }
+  }
+
+  rule pref_fusion {
+    pattern { 
+      N [!ExtPos];
+      N -[deep=m]-> M;  % M is attached with the :m extension
+      M < N          % M is a prefix
+    }  
+    without { M -> X}         % M is a leaf (force application order)
+    commands { 
+      N.form = M.form + N.form;  % concatenate the surface form
+      N.wordform = M.wordform + N.wordform;  % concatenate the surface form
+      N.lemma = M.lemma + N.lemma;           % concatenate the surface lemma
+      del_node M;                % concatenate the surface form
+    }
+  }
+}
+

--- a/converter/grs/zh_mSUD_to_UD.grs
+++ b/converter/grs/zh_mSUD_to_UD.grs
@@ -1,0 +1,57 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+include "SUD_to_UD.grs"
+include "zh_mSUD_to_SUD.grs"
+
+strat zh_mSUD_to_UD_main { 
+  Seq (
+    zh_mSUD_to_SUD_main,
+    Onf (comp),
+    u_main,
+    Onf (zh_post)
+  )
+}
+
+package comp {
+  rule obl {
+    pattern { 
+      e: N -[comp]-> M; N[form <> "的"];
+      M [upos=ADP|PART];
+    }
+    commands { e.2 = obl }
+  }
+
+  rule obj {
+    pattern { 
+      e: N -[comp]-> M; N[form <> "的"];
+      M [upos=NOUN|PROPN|PRON|VERB|AUX];
+    }
+    commands { e.2 = obj }
+  }
+
+  rule obj2 {
+    pattern { 
+      e: N -[comp]-> M; N[form = "的"];
+    }
+    commands { e.2 = obj }
+  }
+}
+
+package zh_post {
+  rule obl_mod {
+    pattern {
+      e: N -[obl:mod]-> M;
+    }
+    commands {
+      del_feat e.2;
+    }
+  }
+
+  rule dep_comp {
+    pattern {
+      e: N -[dep:comp]-> M;
+    }
+    commands {
+      del_feat e.2;
+    }
+  }
+}

--- a/validator/Makefile
+++ b/validator/Makefile
@@ -15,10 +15,12 @@ valid:
 clean:
 	grew_dev clean -i sud_fr.json
 	grew_dev clean -i sud_pcm.json
+	grew_dev clean -i sud_zh.json
 
 compile:
 	grew_dev compile -i sud_fr.json
 	grew_dev compile -i sud_pcm.json
+	grew_dev compile -i sud_zh.json
 
 url:
 	@echo "http://localhost:8888/validator/?corpus=SUD_French-GSD@latest"

--- a/validator/Makefile
+++ b/validator/Makefile
@@ -25,3 +25,4 @@ url:
 	@echo "http://localhost:8888/validator/?corpus=SUD_French-Rhapsodie@latest"
 	@echo "http://localhost:8888/validator/?corpus=SUD_French-ParisStories@latest"
 	@echo "http://localhost:8888/validator/?corpus=SUD_Naija-NSC@latest"
+	@echo "http://localhost:8888/validator/?corpus=SUD_Chinese-Beginner@latest"

--- a/validator/Makefile
+++ b/validator/Makefile
@@ -8,6 +8,7 @@ valid:
 	# remove old validations
 	rm -f ~/.local/www/grew/valid/*.json
 	grew_dev valid -pattern "modules/global.json modules/relations.json modules/obsolete.json modules/idioms.json modules/french_agreement.json" -i sud_fr.json -o ~/.local/www/grew/valid
+	grew_dev valid -pattern "modules/global.json modules/relations.json modules/obsolete.json modules/idioms.json modules/zh_char.json" -i sud_zh.json -o ~/.local/www/grew/valid
 	grew_dev valid -pattern "modules/global.json modules/relations.json modules/obsolete.json modules/idioms.json" -i sud_pcm.json -o ~/.local/www/grew/valid
 	cp html/index.html ~/.local/www/grew/valid
 

--- a/validator/html/index.html
+++ b/validator/html/index.html
@@ -32,8 +32,8 @@
             table.append('<colgroup><col style="width: 10%;"><col style="width: 90%;"></colgroup>');
 
             module.items.forEach((item) => {
-              let pattern_uri = encodeURIComponent(item.pattern.join('\n'));
-              let link = 'http://match.grew.fr/?corpus=' + data.corpus + '&pattern=' + pattern_uri;
+              let request_uri = encodeURIComponent(item.request.join('\n'));
+              let link = 'http://match.grew.fr/?corpus=' + data.corpus + '&request=' + request_uri;
               let row = "";
               if (item.count > 0) {
                 if (item.level == "error") {

--- a/validator/modules/zh_char.json
+++ b/validator/modules/zh_char.json
@@ -1,0 +1,19 @@
+{
+    "title": "Détection des erreurs d'annotation du chinois mandarin (mSUD)",
+    "languages": ["zh"],
+    "items": [
+  
+      {
+        "description": "Seul la tête d'une unité de mot peut gouverner d'autres unités syntaxiques",
+        "request": [
+          "pattern {",
+          "  e: N1 -> N2;",
+          "  e2: N2 -> N3;",
+          "  e.deep = m;",
+          "}",
+          "without { e2.deep=m }"
+        ],
+        "level": "error"
+      }
+    ]
+  }

--- a/validator/sud_zh.json
+++ b/validator/sud_zh.json
@@ -1,0 +1,9 @@
+{
+  "corpora": [
+    {
+      "id": "SUD_Chinese-Beginner",
+      "config": "sud",
+      "directory": "/Users/guillaum/resources/sud-treebanks-current/SUD_Chinese-Beginner"
+    }
+  ]
+}

--- a/validator/sud_zh.json
+++ b/validator/sud_zh.json
@@ -1,7 +1,7 @@
 {
   "corpora": [
     {
-      "id": "SUD_Chinese-Beginner",
+      "id": "SUD_Chinese-Beginner@latest",
       "config": "sud",
       "directory": "/Users/guillaum/resources/sud-treebanks-current/SUD_Chinese-Beginner"
     }


### PR DESCRIPTION
I would like to add 
- conversion rules to transform mSUD to SUD for mandarin chinese
- verification rules to check the sanity of mSUD mandarin chinese

This is done for the native SUD treebank https://github.com/surfacesyntacticud , but an effort of uniformization and compatibilty is in procoss for https://github.com/surfacesyntacticud/SUD_Chinese-PatentChar 