### PR TITLE
refactor: chinese zh rules to have better modularity between mSUD SUD and UD conversions

### DIFF
--- a/converter/grs/zh_SUD_to_UD.grs
+++ b/converter/grs/zh_SUD_to_UD.grs
@@ -1,7 +1,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 include "SUD_to_UD.grs"
 
-strat zh_main { 
+strat zh_SUD_to_UD_main { 
   Seq (
     Onf (comp),
     u_main,

--- a/converter/grs/zh_mSUD_to_UD.grs
+++ b/converter/grs/zh_mSUD_to_UD.grs
@@ -5,53 +5,6 @@ include "zh_mSUD_to_SUD.grs"
 strat zh_mSUD_to_UD_main { 
   Seq (
     zh_mSUD_to_SUD_main,
-    Onf (comp),
-    u_main,
-    Onf (zh_post)
+    zh_SUD_to_UD_main,
   )
-}
-
-package comp {
-  rule obl {
-    pattern { 
-      e: N -[comp]-> M; N[form <> "的"];
-      M [upos=ADP|PART];
-    }
-    commands { e.2 = obl }
-  }
-
-  rule obj {
-    pattern { 
-      e: N -[comp]-> M; N[form <> "的"];
-      M [upos=NOUN|PROPN|PRON|VERB|AUX];
-    }
-    commands { e.2 = obj }
-  }
-
-  rule obj2 {
-    pattern { 
-      e: N -[comp]-> M; N[form = "的"];
-    }
-    commands { e.2 = obj }
-  }
-}
-
-package zh_post {
-  rule obl_mod {
-    pattern {
-      e: N -[obl:mod]-> M;
-    }
-    commands {
-      del_feat e.2;
-    }
-  }
-
-  rule dep_comp {
-    pattern {
-      e: N -[dep:comp]-> M;
-    }
-    commands {
-      del_feat e.2;
-    }
-  }
 }

--- a/converter/test2/tests_description.json
+++ b/converter/test2/tests_description.json
@@ -8,7 +8,7 @@
     {
         "TEST_FOLDER_NAME": "zh_SUD_to_UD",
         "GRS_FILE": "zh_SUD_to_UD.grs",
-        "STRAT_NAME": "zh_main",
+        "STRAT_NAME": "zh_SUD_to_UD_main",
         "CONFIG_TYPE": "sud"
     }
 ]


### PR DESCRIPTION
This is a small refactor of the chinese grs rules between mSUD SUD and UD as the mSUD->UD is completely defined (and thus can inherit) in mSUD_to_SUD and SUD_to_UD.

The name of the main strat in each of these files is following the same pattern {NAME_OF_FILE}_main , for instance zh_SUD_to_UD_main . This is a breaking change, as one of this name changes from zh_main to zh_SUD_to_UD_main .

Thanks in advance for reviewing this !